### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.0 - 2023-03-27
+
+### Changed
+
+* `connect_sse()` and `aconnect_sse()` now require a `method` argument: `connect_sse(client, "GET", "https://example.org")`. This provides support for SSE requests with HTTP verbs other than `GET`. (Pull #7)
+
 ## 0.1.0 - 2023-02-05
 
 _Initial release_

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Consume [Server-Sent Event (SSE)](https://html.spec.whatwg.org/multipage/server-
 **NOTE**: This is alpha software. Please be sure to pin your dependencies.
 
 ```bash
-pip install httpx-sse=="0.1.*"
+pip install httpx-sse=="0.2.*"
 ```
 
 ## Quickstart

--- a/src/httpx_sse/__init__.py
+++ b/src/httpx_sse/__init__.py
@@ -2,7 +2,7 @@ from ._api import EventSource, aconnect_sse, connect_sse
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## 0.2.0 - 2023-03-27

### Changed

* `connect_sse()` and `aconnect_sse()` now require a `method` argument: `connect_sse(client, "GET", "https://example.org")`. This provides support for SSE requests with HTTP verbs other than `GET`. (Pull #7)
