### PR TITLE
Moved the logic that checks if content_type is text/event-stream

### DIFF
--- a/src/httpx_sse/_api.py
+++ b/src/httpx_sse/_api.py
@@ -23,7 +23,7 @@ class EventSource:
     @property
     def response(self) -> httpx.Response:
         return self._response
-            
+
     def iter_sse(self) -> Iterator[ServerSentEvent]:
         self._check_content_type()
         decoder = SSEDecoder()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,8 +31,9 @@ def test_connect_sse_non_event_stream_received() -> None:
 
     with httpx.Client(transport=httpx.MockTransport(handler)) as client:
         with pytest.raises(SSEError, match="text/event-stream"):
-            with connect_sse(client, "GET", "http://testserver") as _:
-                pass  # pragma: no cover
+            with connect_sse(client, "GET", "http://testserver") as event_source:
+                for _ in event_source.iter_sse():
+                    pass  # pragma: no cover
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Moved the logic that checks for content_type into a separated function _check_content_type that is now called from iter_sse and aiter_sse instead of the constructor.

This should allow now to check if request was successful or not and handle the errors.

See #11 

This should allow now for:
```python
import httpx
from httpx_sse import connect_sse

with httpx.Client() as client:
    with connect_sse(client, "GET", "http://localhost:8000/sse") as event_source:
        if not event_source.response.is_success:
            # handle errors
            pass

        for sse in event_source.iter_sse():
            print(sse.event, sse.data, sse.id, sse.retry)
```