### PR TITLE
Version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.3.0 - 2023-04-27
+
+### Changed
+
+* Raising an `SSEError` if the response content type is not `text/event-stream` is now performed as part of `iter_sse()` / `aiter_sse()`, instead of `connect_sse()` / `aconnect_sse()`. This allows inspecting the response before iterating on server-sent events, such as checking for error responses. (Pull #12)
+
 ## 0.2.0 - 2023-03-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Consume [Server-Sent Event (SSE)](https://html.spec.whatwg.org/multipage/server-
 
 ## Installation
 
-**NOTE**: This is alpha software. Please be sure to pin your dependencies.
+**NOTE**: This is beta software. Please be sure to pin your dependencies.
 
 ```bash
-pip install httpx-sse=="0.2.*"
+pip install httpx-sse=="0.3.*"
 ```
 
 ## Quickstart

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
   { name = "Florimond Manca", email = "florimond.manca@protonmail.com" },
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",

--- a/src/httpx_sse/__init__.py
+++ b/src/httpx_sse/__init__.py
@@ -2,7 +2,7 @@ from ._api import EventSource, aconnect_sse, connect_sse
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## 0.3.0 - 2023-04-27

### Changed

* Raising an `SSEError` if the response content type is not `text/event-stream` is now performed as part of `iter_sse()` / `aiter_sse()`, instead of `connect_sse()` / `aconnect_sse()`. This allows inspecting the response before iterating on server-sent events, such as checking for error responses. (Pull #12)
