### PR TITLE
feat: support when text/event-stream is not the only content-type

### DIFF
--- a/src/httpx_sse/_api.py
+++ b/src/httpx_sse/_api.py
@@ -14,7 +14,7 @@ class EventSource:
 
     def _check_content_type(self) -> None:
         content_type, _, _ = self._response.headers["content-type"].partition(";")
-        if content_type != "text/event-stream":
+        if "text/event-stream" not in content_type:
             raise SSEError(
                 "Expected response Content-Type to be 'text/event-stream', "
                 f"got {content_type!r}"


### PR DESCRIPTION
First of all, thank you for this package, it is very useful !

I'm opening this PR to tackle an issue when using this package to consume events sent by the [Nvidia Triton Inference Server Generate Extension](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/protocol/extension_generate.html).

The extension uses `application/json, text/event-stream; charset=utf-8` as `content_type`, and thus, the method `_check_content_type()` was failing. By checking if `text/event-stream` is contained in the string, the issue is resolved.