### PR TITLE
Nice-ified missing `content-type`

### DIFF
--- a/src/httpx_sse/_api.py
+++ b/src/httpx_sse/_api.py
@@ -13,10 +13,13 @@ class EventSource:
         self._response = response
 
     def _check_content_type(self) -> None:
-        content_type, _, _ = self._response.headers["content-type"].partition(";")
+        try:
+            content_type, _, _ = self._response.headers["content-type"].partition(";")
+        except KeyError as exc:
+            raise SSEError("Expected response to have a Content-Type header.") from exc
         if content_type != "text/event-stream":
             raise SSEError(
-                "Expected response Content-Type to be 'text/event-stream', "
+                "Expected response Content-Type header to be 'text/event-stream', "
                 f"got {content_type!r}"
             )
 

--- a/src/httpx_sse/_api.py
+++ b/src/httpx_sse/_api.py
@@ -13,7 +13,7 @@ class EventSource:
         self._response = response
 
     def _check_content_type(self) -> None:
-        content_type, _, _ = self._response.headers.get("content-type", "").partition(";")
+        content_type = self._response.headers.get("content-type", "").partition(";")[0]
         if content_type != "text/event-stream":
             raise SSEError(
                 "Expected response header Content-Type to be 'text/event-stream', "

--- a/src/httpx_sse/_api.py
+++ b/src/httpx_sse/_api.py
@@ -13,13 +13,10 @@ class EventSource:
         self._response = response
 
     def _check_content_type(self) -> None:
-        try:
-            content_type, _, _ = self._response.headers["content-type"].partition(";")
-        except KeyError as exc:
-            raise SSEError("Expected response to have a Content-Type header.") from exc
+        content_type, _, _ = self._response.headers.get("content-type", "").partition(";")
         if content_type != "text/event-stream":
             raise SSEError(
-                "Expected response Content-Type header to be 'text/event-stream', "
+                "Expected response header Content-Type to be 'text/event-stream', "
                 f"got {content_type!r}"
             )
 


### PR DESCRIPTION
Nice-ified the error when the `content-type` header is missing