### PR TITLE
Test on Python 3.12, and drop 3.7

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/tags/6.0
+      ref: refs/tags/6.2
 
 trigger:
   - master
@@ -25,13 +25,13 @@ stages:
     jobs:
       - template: job--python-check.yml@templates
         parameters:
-          pythonVersion: "3.11"
+          pythonVersion: "3.12"
 
       - template: job--python-test.yml@templates
         parameters:
           jobs:
             py38:
-            py311:
+            py312:
               coverage: true
 
   - stage: publish
@@ -39,5 +39,5 @@ stages:
     jobs:
       - template: job--python-publish.yml@templates
         parameters:
-          pythonVersion: "3.11"
+          pythonVersion: "3.12"
           token: $(pypiToken)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "httpx-sse"
 description = "Consume Server-Sent Event (SSE) messages with HTTPX."
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [
   { name = "Florimond Manca", email = "florimond.manca@protonmail.com" },
@@ -15,11 +15,11 @@ classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = []
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This will allow us to claim "official Python 3.12 support".

[Python 3.7 has reached EOL](https://endoflife.date/python) and e.g. sse-starlette (used for tests, but still) does not support it anymore.