### PR TITLE
Version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.4.0 - 2023-12-22
+
+### Removed
+
+* Dropped Python 3.7 support, as it has reached EOL. (Pull #21)
+
+### Added
+
+* Add official support for Python 3.12. (Pull #21)
+
+### Fixed
+
+* Allow `Content-Type` that contain but are not strictly `text/event-stream`. (Pull #22 by @dbuades)
+* Improve error message when `Content-Type` is missing. (Pull #20 by @jamesbraza)
+
 ## 0.3.1 - 2023-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Consume [Server-Sent Event (SSE)](https://html.spec.whatwg.org/multipage/server-
 **NOTE**: This is beta software. Please be sure to pin your dependencies.
 
 ```bash
-pip install httpx-sse=="0.3.*"
+pip install httpx-sse=="0.4.*"
 ```
 
 ## Quickstart

--- a/src/httpx_sse/__init__.py
+++ b/src/httpx_sse/__init__.py
@@ -2,7 +2,7 @@ from ._api import EventSource, aconnect_sse, connect_sse
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## 0.4.0 - 2023-12-22

### Removed

* Dropped Python 3.7 support, as it has reached EOL. (Pull #21)

### Added

* Add official support for Python 3.12. (Pull #21)

### Fixed

* Allow `Content-Type` that contain but are not strictly `text/event-stream`. (Pull #22 by @dbuades)
* Improve error message when `Content-Type` is missing. (Pull #20 by @jamesbraza)
