### PR TITLE
chore: Migrate test case and bump python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ async def auth_events(request):
 app = Starlette(routes=[Route("/sse/auth/", endpoint=auth_events)])
 
 async def main():
-    async with httpx.AsyncClient(app=app) as client:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app)) as client:
         async with aconnect_sse(
             client, "GET", "http://localhost:8000/sse/auth/"
         ) as event_source:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/tags/6.2
+      ref: refs/tags/6.3
 
 trigger:
   - master
@@ -25,13 +25,13 @@ stages:
     jobs:
       - template: job--python-check.yml@templates
         parameters:
-          pythonVersion: "3.12"
+          pythonVersion: "3.13"
 
       - template: job--python-test.yml@templates
         parameters:
           jobs:
             py39:
-            py312:
+            py313:
               coverage: true
 
   - stage: publish
@@ -39,5 +39,5 @@ stages:
     jobs:
       - template: job--python-publish.yml@templates
         parameters:
-          pythonVersion: "3.12"
+          pythonVersion: "3.13"
           token: $(pypiToken)

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -25,13 +25,13 @@ stages:
     jobs:
       - template: job--python-check.yml@templates
         parameters:
-          pythonVersion: "3.13"
+          pythonVersion: "3.12"
 
       - template: job--python-test.yml@templates
         parameters:
           jobs:
             py39:
-            py313:
+            py312:
               coverage: true
 
   - stage: publish
@@ -39,5 +39,5 @@ stages:
     jobs:
       - template: job--python-publish.yml@templates
         parameters:
-          pythonVersion: "3.13"
+          pythonVersion: "3.12"
           token: $(pypiToken)

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -25,13 +25,13 @@ stages:
     jobs:
       - template: job--python-check.yml@templates
         parameters:
-          pythonVersion: "3.12"
+          pythonVersion: "3.13"
 
       - template: job--python-test.yml@templates
         parameters:
           jobs:
-            py38:
-            py312:
+            py39:
+            py313:
               coverage: true
 
   - stage: publish
@@ -39,5 +39,5 @@ stages:
     jobs:
       - template: job--python-publish.yml@templates
         parameters:
-          pythonVersion: "3.12"
+          pythonVersion: "3.13"
           token: $(pypiToken)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "httpx-sse"
 description = "Consume Server-Sent Event (SSE) messages with HTTPX."
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [
   { name = "Florimond Manca", email = "florimond.manca@protonmail.com" },
@@ -15,11 +15,11 @@ classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = []
 dynamic = ["version", "readme"]

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -29,7 +29,7 @@ def app() -> ASGIApp:
 
 @pytest_asyncio.fixture
 async def client(app: ASGIApp) -> AsyncIterator[httpx.AsyncClient]:
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app)) as client: # type: ignore[arg-type]
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app)) as client:  # type: ignore[arg-type]
         yield client
 
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator
+from typing import AsyncIterator, cast
 
 import httpx
 import pytest
@@ -29,7 +29,7 @@ def app() -> ASGIApp:
 
 @pytest_asyncio.fixture
 async def client(app: ASGIApp) -> AsyncIterator[httpx.AsyncClient]:
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app)) as client:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app)) as client: # type: ignore[arg-type]
         yield client
 
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, cast
+from typing import AsyncIterator
 
 import httpx
 import pytest

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -29,7 +29,7 @@ def app() -> ASGIApp:
 
 @pytest_asyncio.fixture
 async def client(app: ASGIApp) -> AsyncIterator[httpx.AsyncClient]:
-    async with httpx.AsyncClient(app=app) as client:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app)) as client:
         yield client
 
 


### PR DESCRIPTION
closes #28 

One more thing, Python 3.8 is EOL, we'd better test Python 3.9-3.13