### PR TITLE
Ensure that all async generators are explicitly closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+* Always close the response async generator in `aiter_sse()`
+
 ## 0.4.0 - 2023-12-22
 
 ### Removed

--- a/src/httpx_sse/_api.py
+++ b/src/httpx_sse/_api.py
@@ -34,7 +34,7 @@ class EventSource:
             if sse is not None:
                 yield sse
 
-    async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent]:
+    async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
         lines = self._response.aiter_lines()

--- a/src/httpx_sse/_api.py
+++ b/src/httpx_sse/_api.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncIterator, Iterator
+from typing import Any, AsyncIterator, Iterator, cast
 
 import httpx
 
@@ -37,7 +37,7 @@ class EventSource:
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        lines = self._response.aiter_lines()
+        lines = cast(AsyncGenerator[str, None], self._response.aiter_lines())
         try:
             async for line in lines:
                 line = line.rstrip("\n")


### PR DESCRIPTION
If this is not done, it will be up to the event loop's asyncgen finalizer to do the closing, and there's no telling when it will happen. Additionally, Trio will emit a warning whenever the finalizer detects an unclosed async generator.