### PR TITLE
Version 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## 0.4.1 - 2025-06-24
 
 ### Fixed
 
-* Always close the response async generator in `aiter_sse()`
+* Always close the response async generator in `aiter_sse()`. (Pull #30)
 
 ## 0.4.0 - 2023-12-22
 

--- a/src/httpx_sse/__init__.py
+++ b/src/httpx_sse/__init__.py
@@ -2,7 +2,7 @@ from ._api import EventSource, aconnect_sse, connect_sse
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## 0.4.1 - 2025-06-24

### Fixed

* Always close the response async generator in `aiter_sse()`. (Pull #30)

